### PR TITLE
ghuser cpython task has its own configuration section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Task `build-cpython-ghuser-components` now uses `ghuser_cpython` configuration key.
+
 ### Removed
 
 

--- a/src/compas_invocations2/build.py
+++ b/src/compas_invocations2/build.py
@@ -149,9 +149,9 @@ def build_ghuser_components(ctx, gh_io_folder=None, ironpython=None, prefix=None
 )
 def build_cpython_ghuser_components(ctx, gh_io_folder=None, prefix=None):
     """Builds CPython Grasshopper components using GH Componentizer."""
-    prefix = prefix or getattr(ctx.ghuser, "prefix", None)
-    source_dir = os.path.abspath(ctx.ghuser.source_dir)
-    target_dir = os.path.abspath(ctx.ghuser.target_dir)
+    prefix = prefix or getattr(ctx.ghuser_cpython, "prefix", None)
+    source_dir = os.path.abspath(ctx.ghuser_cpython.source_dir)
+    target_dir = os.path.abspath(ctx.ghuser_cpython.target_dir)
     repo_url = "https://github.com/compas-dev/compas-actions.ghpython_components.git"
 
     with chdir(ctx.base_folder):


### PR DESCRIPTION
Since SDK mode CPython GH components in Rhino8 have a different interface (and are python3..) than the previous GHPython ones, their definition would need to be separated from the Rhino7 components.

The change it this PR is that `build-cpython-ghuser-components` expects its own configuration section in context `ghuser_cpython`. This allow the client to set different source/target paths for Rhino7/IPY and Rhino8/CPython components in the same repository.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
