### PR TITLE
replaced discontinued `toml` with `tomlkit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Replaced `toml` with `tomlkit` as the former is not available for python past 3.9. 
+
 ### Removed
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ ruff
 sphinx_compas2_theme
 twine
 wheel
-toml
+tomlkit

--- a/src/compas_invocations2/grasshopper.py
+++ b/src/compas_invocations2/grasshopper.py
@@ -12,7 +12,7 @@ import tempfile
 
 import invoke
 import requests
-import toml
+import tomlkit
 
 from compas_invocations2.console import chdir
 
@@ -58,7 +58,11 @@ def _clear_directory(path_to_dir):
 
 
 def _get_version_from_toml(toml_file: str) -> str:
-    pyproject_data = toml.load(toml_file)
+    with open(toml_file, "r") as f:
+        pyproject_data = tomlkit.load(f)
+    if not pyproject_data:
+        raise invoke.Exit("Failed to load pyproject.toml.")
+
     version = pyproject_data.get("tool", {}).get("bumpversion", {}).get("current_version", None)
     if not version:
         raise invoke.Exit("Failed to get version from pyproject.toml. Please provide a version number.")


### PR DESCRIPTION
`toml` is not available for newer python released. replaced it with tomlkit.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [x] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
