### PR TITLE
added script to update gh component header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added task `update-gh-header` to `grasshopper` tasks.
+
 ### Changed
 
 ### Removed

--- a/src/compas_invocations2/grasshopper.py
+++ b/src/compas_invocations2/grasshopper.py
@@ -174,7 +174,9 @@ def yakerize(
         os.rename(taget_file, new_filename)
 
 
-@invoke.task(help={"yak_file": "Path to the .yak file to publish.", "test_server": "True to publish to the test server."})
+@invoke.task(
+    help={"yak_file": "Path to the .yak file to publish.", "test_server": "True to publish to the test server."}
+)
 def publish_yak(ctx, yak_file: str, test_server: bool = False):
     """Publish a YAK package to the YAK server."""
 


### PR DESCRIPTION
Introduces `invoke update-gh-header` which let's you set a new minimum library version in the header of all cpython grasshopper components.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
