### PR TITLE
Dev header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added flag `dev` to `update-gh-header`.
+* Added argument `venv` to `update-gh-header`.
+* Added argument `envs` to `update-gh-header`.
+
 ### Changed
 
 ### Removed

--- a/src/compas_invocations2/grasshopper.py
+++ b/src/compas_invocations2/grasshopper.py
@@ -214,8 +214,8 @@ def publish_yak(ctx, yak_file: str, test_server: bool = False):
 @invoke.task(
     help={
         "version": "New minimum version to set in the header. If not provided, current version is used.",
-        "venv": "Name of the Rhino virtual environment to activate, if any.",
-        "no_dep": "If True, the dependency header is ommitted to allow using the package in development mode.",
+        "venv": "(Optional) Name of the Rhino virtual environment to use in the components.",
+        "no_dep": "(Defaults to False) If True, the dependency header is ommitted. This may be useful for development.",
     }
 )
 def update_gh_header(ctx, version=None, venv=None, no_dep=False):


### PR DESCRIPTION
Added 3 new arguments to `update-gh-header` to allow creating development variants of CPython GH plugins.
* `dev` - boolean flag, when `True`: 
    * omits the dependency part of the header (`#r: ...`)
    * adds the package path to the header as `env` 

This prevents Rhino from installing your package from pypi and using the "editable" version directly from the repo

* `venv` - allows specifying a `venv` section in the header
*  `envs` - allows specifying a list of `;` delimited paths to be added as `env` 

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
