### PR TITLE
bump version as pre-release or release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added support for bumping to pre-release and release candidate versions with `release` task.
+
 ### Changed
 
 ### Removed

--- a/src/compas_invocations2/build.py
+++ b/src/compas_invocations2/build.py
@@ -53,7 +53,7 @@ def clean(ctx, docs=True, bytecode=True, builds=True, ghuser=True):
 @invoke.task(help={"release_type": "Type of release follows semver rules. Must be one of: major, minor, patch."})
 def release(ctx, release_type):
     """Releases the project in one swift command!"""
-    if release_type not in ("patch", "minor", "major"):
+    if release_type not in ("patch", "minor", "major", "pre_l", "pre_n"):
         raise invoke.Exit("The release type parameter is invalid.\nMust be one of: major, minor, patch.")
 
     # Run formatter

--- a/src/compas_invocations2/build.py
+++ b/src/compas_invocations2/build.py
@@ -50,7 +50,9 @@ def clean(ctx, docs=True, bytecode=True, builds=True, ghuser=True):
             shutil.rmtree(os.path.join(ctx.base_folder, folder), ignore_errors=True)
 
 
-@invoke.task(help={"release_type": "Type of release follows semver rules. Must be one of: major, minor, patch."})
+@invoke.task(
+    help={"release_type": "Type of release follows semver rules. Must be one of: major, minor, patch, pre_l, pre_n."}
+)
 def release(ctx, release_type):
     """Releases the project in one swift command!"""
     if release_type not in ("patch", "minor", "major", "pre_l", "pre_n"):


### PR DESCRIPTION
Added support for bumping to pre-release and release candidate versions with `release` task.

NOTE: 
to enable pre-release and release candidate, the following must also be present in `pyproject.toml`

```
[tool.bumpversion]
...
parse = """(?x)
    (?P<major>0|[1-9]\\d*)\\.
    (?P<minor>0|[1-9]\\d*)\\.
    (?P<patch>0|[1-9]\\d*)
    (?:
        -                             # dash separator for pre-release section
        (?P<pre_l>[a-zA-Z-]+)         # pre-release label
        (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
    )?                                # pre-release section is optional
"""
serialize = [
    "{major}.{minor}.{patch}-{pre_l}{pre_n}",
    "{major}.{minor}.{patch}",
]

[tool.bumpversion.parts.pre_l]
values = ["dev", "rc", "final"]
optional_value = "final"
```

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [ ] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [ ] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
