### PR TITLE
Fix prepare changelog task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Removed extra line break from prepare changelog template.
+* Prevented adding several unreleased sections to changelog.
+
 ### Removed
 
 

--- a/src/compas_invocations2/build.py
+++ b/src/compas_invocations2/build.py
@@ -92,7 +92,7 @@ def release(ctx, release_type):
 @invoke.task
 def prepare_changelog(ctx):
     """Prepare changelog for next release."""
-    UNRELEASED_CHANGELOG_TEMPLATE = "## Unreleased\n\n### Added\n\n### Changed\n\n### Removed\n\n\n## "
+    UNRELEASED_CHANGELOG_TEMPLATE = "## Unreleased\n\n### Added\n\n### Changed\n\n### Removed\n\n## "
 
     with chdir(ctx.base_folder):
         # Preparing changelog for next release

--- a/src/compas_invocations2/build.py
+++ b/src/compas_invocations2/build.py
@@ -98,6 +98,8 @@ def prepare_changelog(ctx):
         # Preparing changelog for next release
         with open("CHANGELOG.md", "r+") as changelog:
             content = changelog.read()
+            if "\n## Unreleased\n" in content:
+                raise RuntimeError("Changelog already contains an unreleased section")
             changelog.seek(0)
             changelog.write(content.replace("## ", UNRELEASED_CHANGELOG_TEMPLATE, 1))
 


### PR DESCRIPTION
Micro-PR (µPR) that modifies the `prepare_changelog` task from "compas_invocations2.build":

- Modifies `UNRELEASED_CHANGELOG_TEMPLATE` to remove extra line break. This additional whitespace generates code that is not compliant with Markdown linters.
- Adds check to prevent more than one "Unreleased" section in the changelog.

> [!NOTE]
> Related to gramaziokohler/compas_cadwork#49.