### PR TITLE
Normalize new lines in prepare changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Normalized new lines in `prepare_changelog` to always use LF regardless of the platform.
+
 ### Removed
 
 ## [1.2.0] 2026-08-03

--- a/src/compas_invocations2/build.py
+++ b/src/compas_invocations2/build.py
@@ -96,7 +96,7 @@ def prepare_changelog(ctx):
 
     with chdir(ctx.base_folder):
         # Preparing changelog for next release
-        with open("CHANGELOG.md", "r+") as changelog:
+        with open("CHANGELOG.md", "r+", newline="") as changelog:
             content = changelog.read()
             if "\n## Unreleased\n" in content:
                 raise RuntimeError("Changelog already contains an unreleased section")


### PR DESCRIPTION
Running the `prepare_changelog` task on Windows corrupted the CHANGELOG.md file, as the default new line bytes for that platform are CRLF (`\r\n`). However, we always use `\n` in COMPAS projects.

This tiny PR ensures thats Python always uses LF (`\n`) for preparing the changelog regardless of the Operating System.